### PR TITLE
feat(input types): Generate update input types with nullable fields

### DIFF
--- a/examples/simple/src/index.ts
+++ b/examples/simple/src/index.ts
@@ -9,12 +9,12 @@ const PORT = 3000;
 
 const typeDefs = `
   type Item @model {
-    name: String
+    name: String!
     subItem: SubItem
   }
 
   type SubItem {
-    name: String
+    name: String!
   }
 
   type Query {

--- a/packages/graphql-crud/src/index.ts
+++ b/packages/graphql-crud/src/index.ts
@@ -7,6 +7,7 @@ export * from './generateFieldNames';
 export * from './omitResolvers';
 export * from './addInputTypesForObjectType';
 export * from './util';
+export * from './validateUpdateInputData';
 
 import { DefaultDirective } from './DefaultDirective';
 import { ModelDirective } from './ModelDirective';

--- a/packages/graphql-crud/src/index.ts
+++ b/packages/graphql-crud/src/index.ts
@@ -6,6 +6,7 @@ export * from './Store';
 export * from './generateFieldNames';
 export * from './omitResolvers';
 export * from './addInputTypesForObjectType';
+export * from './util';
 
 import { DefaultDirective } from './DefaultDirective';
 import { ModelDirective } from './ModelDirective';

--- a/packages/graphql-crud/src/util.ts
+++ b/packages/graphql-crud/src/util.ts
@@ -1,0 +1,21 @@
+import {
+  getNamedType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLSchema,
+} from 'graphql';
+
+export const toInputObjectTypeName = (name: string): string => `${name}InputType`;
+
+export const isValidInputType = (type, schema: GraphQLSchema): boolean => {
+  if (type instanceof GraphQLList) {
+    return isValidInputType(getNamedType(type), schema);
+  }
+  return !(type instanceof GraphQLObjectType);
+};
+
+export const getInputType = (typeName: string, schema: GraphQLSchema): GraphQLInputObjectType => {
+  const type = schema.getType(toInputObjectTypeName(typeName));
+  return type as GraphQLInputObjectType;
+};

--- a/packages/graphql-crud/src/util.ts
+++ b/packages/graphql-crud/src/util.ts
@@ -1,5 +1,6 @@
 import {
   getNamedType,
+  getNullableType,
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLObjectType,
@@ -12,7 +13,7 @@ export const isValidInputType = (type, schema: GraphQLSchema): boolean => {
   if (type instanceof GraphQLList) {
     return isValidInputType(getNamedType(type), schema);
   }
-  return !(type instanceof GraphQLObjectType);
+  return !(getNullableType(type) instanceof GraphQLObjectType);
 };
 
 export const getInputType = (typeName: string, schema: GraphQLSchema): GraphQLInputObjectType => {

--- a/packages/graphql-crud/src/validateUpdateInputData.ts
+++ b/packages/graphql-crud/src/validateUpdateInputData.ts
@@ -1,0 +1,46 @@
+import {
+  getNullableType,
+  GraphQLObjectType,
+  GraphQLSchema,
+} from 'graphql';
+
+import {
+  isEmpty,
+  isPlainObject,
+} from 'lodash';
+
+export interface ValidateUpdateInputDataProps {
+  type: GraphQLObjectType;
+  schema: GraphQLSchema;
+  data: object;
+}
+
+// For every null value in the input data
+// check that it can be nullable by check the type definition.
+export const validateUpdateInputData = (props: ValidateUpdateInputDataProps) => {
+  if (isEmpty(props.data)) {
+    throw new Error('data input object is missing');
+  }
+
+  const isNonNullable = (type) => type.astNode.type.kind === 'NonNullType';
+
+  const fields = props.type.getFields();
+
+  Object
+    .keys(props.data)
+    .forEach((key) => {
+      const field = fields[key];
+      const value = props.data[key];
+      if (isPlainObject(value)) {
+        validateUpdateInputData({
+          schema: props.schema,
+          data: value,
+          type: getNullableType(field.type) as any,
+        });
+      } else {
+        if (value === null && isNonNullable(field)) {
+          throw new Error(`${props.type.name}.${field.name} must not be null`);
+        }
+      }
+    });
+};

--- a/packages/graphql-crud/test/ModelDirective.test.ts
+++ b/packages/graphql-crud/test/ModelDirective.test.ts
@@ -20,7 +20,7 @@ const baseTypeDefs = `
 describe('ModelDirective', () => {
   const typeDefs = `
   type Foo @model {
-    name: String
+    name: String!
     children: Foo
     parent: Bar
   }
@@ -28,7 +28,7 @@ describe('ModelDirective', () => {
   type Bar {
     names: [String]
     children: [Dummy]
-    parent: Foo
+    parent: Foo!
   }
 
   type Dummy {

--- a/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
+++ b/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
@@ -48,7 +48,7 @@ type Mutation {
   createFoo(data: FooInputType): Foo
 
   \\"\\"\\"Update a Foo\\"\\"\\"
-  updateFoo(data: FooInputType, where: UpdateFooInputType, upsert: Boolean): Boolean
+  updateFoo(data: UpdateFooInputType, where: UpdateFooInputType, upsert: Boolean): Boolean
 
   \\"\\"\\"Remove a Foo\\"\\"\\"
   removeFoo(where: FooInputType): Boolean

--- a/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
+++ b/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
@@ -10,7 +10,7 @@ exports[`ModelDirective produces the expected schema 1`] = `
 input BarInputType {
   names: [String]
   children: [DummyInputType]
-  parent: Foo!
+  parent: FooInputType
 }
 
 type Dummy {
@@ -67,7 +67,7 @@ type Query {
 input UpdateBarInputType {
   names: [String]
   children: [UpdateDummyInputType]
-  parent: Foo
+  parent: UpdateFooInputType
 }
 
 input UpdateDummyInputType {

--- a/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
+++ b/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
@@ -4,13 +4,13 @@ exports[`ModelDirective produces the expected schema 1`] = `
 "type Bar {
   names: [String]
   children: [Dummy]
-  parent: Foo
+  parent: Foo!
 }
 
 input BarInputType {
   names: [String]
   children: [DummyInputType]
-  parent: FooInputType
+  parent: Foo!
 }
 
 type Dummy {
@@ -24,7 +24,7 @@ input DummyInputType {
 }
 
 type Foo {
-  name: String
+  name: String!
   children: Foo
   parent: Bar
 
@@ -33,7 +33,7 @@ type Foo {
 }
 
 input FooInputType {
-  name: String
+  name: String!
   children: FooInputType
   parent: BarInputType
 
@@ -48,7 +48,7 @@ type Mutation {
   createFoo(data: FooInputType): Foo
 
   \\"\\"\\"Update a Foo\\"\\"\\"
-  updateFoo(data: FooInputType, where: FooInputType, upsert: Boolean): Boolean
+  updateFoo(data: FooInputType, where: UpdateFooInputType, upsert: Boolean): Boolean
 
   \\"\\"\\"Remove a Foo\\"\\"\\"
   removeFoo(where: FooInputType): Boolean
@@ -62,6 +62,26 @@ type Query {
 
   \\"\\"\\"Find multiple Foos\\"\\"\\"
   foos(where: FooInputType): [Foo]
+}
+
+input UpdateBarInputType {
+  names: [String]
+  children: [UpdateDummyInputType]
+  parent: Foo
+}
+
+input UpdateDummyInputType {
+  names: [String]
+  parent: UpdateBarInputType
+}
+
+input UpdateFooInputType {
+  name: String
+  children: UpdateFooInputType
+  parent: UpdateBarInputType
+
+  \\"\\"\\"Unique ID\\"\\"\\"
+  id: ID
 }
 "
 `;


### PR DESCRIPTION
Closes #17

- Improved `addInputTypesForObjectType` function to supporting different input type names and field modifier function. 
- Moved helper functions to `util`
- Updated `ModelDirective` consumption of `addInputTypesForObjectType`

- Added `validateUpdateInputData` to validate null values in an update mutation.
- Updated the `update` mutation in `ModelDirective`.
