### PR TITLE
[WIP] Relations between models

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,25 @@ import typeDefs from './typeDefs';
 
 const typeDefs = `
 
-type Item @model {
-  name: String
+type Author @model {
+  name: String!
+  books: [Book]
+  favoriteBook: Book
+}
+
+type Book @model {
+  name: String!
+  authors: [Author]
+}
+
+type Query {
+  _: Boolean
 }
 
 type Mutation {
   _: Boolean
 }
 
-type Query {
-  _: Boolean
-}
 `
 
 const schema = makeExecutableSchema({
@@ -67,14 +75,12 @@ execute(
   schema,
   gql`
   mutation {
-      createItem(
-        data: {
-          name: "hello world"
-        }
-      ) {
-        id
-        name
-      }
+    createAuthor(data: {
+      name:"Leo Tolstoy"
+    }) {
+      id
+      name
+    }
   }
   `
   null,
@@ -85,29 +91,58 @@ execute(
 The above example will generate the following schema with functioning resolvers.
 
 ```graphql
-type Item {
+"type Author {
   name: String
+  books: [Book]
   id: ID
 }
 
-input ItemInputType {
+input AuthorInputType {
   name: String
+  books: [BookInputType]
+  id: ID
+}
+
+type Book {
+  name: String
+  authors: [Author]
+  id: ID
+}
+
+input BookInputType {
+  name: String
+  authors: [AuthorInputType]
   id: ID
 }
 
 type Mutation {
   _: Boolean
-
-  createItem(data: ItemInputType): Item
-  updateItem(data: ItemInputType, where: ItemInputType, upsert: Boolean): Boolean
-  removeItem(where: ItemInputType): Boolean
+  createAuthor(data: AuthorInputType): Author
+  updateAuthor(data: UpdateAuthorInputType, where: UpdateAuthorInputType, upsert: Boolean): Boolean
+  removeAuthor(where: AuthorInputType): Boolean
+  createBook(data: BookInputType): Book
+  updateBook(data: UpdateBookInputType, where: UpdateBookInputType, upsert: Boolean): Boolean
+  removeBook(where: BookInputType): Boolean
 }
 
 type Query {
   _: Boolean
+  author(where: AuthorInputType): Author
+  authors(where: AuthorInputType): [Author]
+  book(where: BookInputType): Book
+  books(where: BookInputType): [Book]
+}
 
-  item(where: ItemInputType): Item
-  items(where: ItemInputType): [Item]
+input UpdateAuthorInputType {
+  name: String
+  books: [UpdateBookInputType]
+  id: ID
+}
+
+input UpdateBookInputType {
+  name: String
+  authors: [UpdateAuthorInputType]
+  id: ID
 }
 ```
 

--- a/examples/simple/src/index.ts
+++ b/examples/simple/src/index.ts
@@ -8,23 +8,24 @@ import { makeExecutableSchema } from 'graphql-tools';
 const PORT = 3000;
 
 const typeDefs = `
-  type Author @model {
-    name: String
-    books: [Book]
-  }
+type Author @model {
+  name: String!
+  books: [Book]
+  favoriteBook: Book
+}
 
-  type Book @model {
-    name: String
-    authors: [Author]
-  }
+type Book @model {
+  name: String!
+  authors: [Author]
+}
 
-  type Query {
-    _: Boolean
-  }
+type Query {
+  _: Boolean
+}
 
-  type Mutation {
-    _: Boolean
-  }
+type Mutation {
+  _: Boolean
+}
 `;
 
 const schema = makeExecutableSchema({

--- a/packages/graphql-crud/src/ModelDirective.ts
+++ b/packages/graphql-crud/src/ModelDirective.ts
@@ -302,6 +302,20 @@ export class ModelDirective extends SchemaDirectiveVisitor {
     };
   }
 
+  // Helper function for adding mutations to the schema
+  private addMutation(field, replaceExisting = false) {
+    if (replaceExisting || !(this.schema.getMutationType() as any).getFields()[field.name]) {
+      (this.schema.getMutationType() as any).getFields()[field.name] = field;
+    }
+  }
+
+  // Helper function for adding queries to the schema
+  private addQuery(field, replaceExisting = false) {
+    if (replaceExisting || !(this.schema.getQueryType() as any).getFields()[field.name]) {
+      (this.schema.getQueryType() as any).getFields()[field.name] = field;
+    }
+  }
+
   private addMutations(type: GraphQLObjectType) {
     const names = generateFieldNames(type.name);
 
@@ -309,7 +323,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
 
     // create mutation
 
-    (this.schema.getMutationType() as any).getFields()[names.mutation.create] = {
+    this.addMutation({
       name: names.mutation.create,
       type,
       description: `Create a ${type.name}`,
@@ -321,11 +335,11 @@ export class ModelDirective extends SchemaDirectiveVisitor {
       ],
       resolve: this.createMutationResolver(type),
       isDeprecated: false,
-    };
+    });
 
     // update mutation
 
-    (this.schema.getMutationType() as any).getFields()[names.mutation.update] = {
+    this.addMutation({
       name: names.mutation.update,
       type,
       description: `Update a ${type.name}`,
@@ -345,11 +359,11 @@ export class ModelDirective extends SchemaDirectiveVisitor {
       ],
       resolve: this.updateResolver(type),
       isDeprecated: false,
-    };
+    });
 
     // remove mutation
 
-    (this.schema.getMutationType() as any).getFields()[names.mutation.remove] = {
+    this.addMutation({
       name: names.mutation.remove,
       type: GraphQLBoolean,
       description: `Remove a ${type.name}`,
@@ -366,7 +380,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
         });
       },
       isDeprecated: false,
-    };
+    });
   }
 
   private addQueries(type: GraphQLObjectType) {
@@ -374,7 +388,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
 
     // find one query
 
-    this.schema.getQueryType().getFields()[names.query.one] = {
+    this.addQuery({
       name: names.query.one,
       type,
       description: `Find one ${type.name}`,
@@ -386,11 +400,11 @@ export class ModelDirective extends SchemaDirectiveVisitor {
       ],
       resolve: this.findOneQueryResolver(type),
       isDeprecated: false,
-    };
+    });
 
     // find many query
 
-    this.schema.getQueryType().getFields()[names.query.many] = {
+    this.addQuery({
       name: names.query.many,
       type: new GraphQLList(type),
       description: `Find multiple ${pluralize.plural(type.name)}`,
@@ -402,6 +416,6 @@ export class ModelDirective extends SchemaDirectiveVisitor {
       ],
       resolve: this.findQueryResolver(type),
       isDeprecated: false,
-    };
+    });
   }
 }

--- a/packages/graphql-crud/src/ModelDirective.ts
+++ b/packages/graphql-crud/src/ModelDirective.ts
@@ -54,8 +54,6 @@ export interface RemoveResolverArgs {
 }
 
 export class ModelDirective extends SchemaDirectiveVisitor {
-  public static UPDATE_INPUT_TYPE_PREFIX = 'Update';
-
   public visitObject(type: GraphQLObjectType) {
     // TODO check that id field does not already exist on type
     // Add an "id" field to the object type.
@@ -86,18 +84,6 @@ export class ModelDirective extends SchemaDirectiveVisitor {
     addInputTypesForObjectType({
       objectType,
       schema: this.schema,
-    });
-
-    // Often times a type will have required fields which the consumer
-    // does not want to include in every update mutation.
-    // In this case we create additional input types for update mutations.
-    // These types are prefixed with `Update`, (for example: `UpdateFooInputType`)
-    // and all non null fields are replaced with nullable fields.
-    // Note: additional validation is added in the `update` resolver.
-    addInputTypesForObjectType({
-      objectType,
-      schema: this.schema,
-      prefix: ModelDirective.UPDATE_INPUT_TYPE_PREFIX,
       modifyField: (field) => {
         field.type = getNullableType(field.type);
         return field;
@@ -346,11 +332,11 @@ export class ModelDirective extends SchemaDirectiveVisitor {
       args: [
         {
           name: 'data',
-          type: getInputType(`${ModelDirective.UPDATE_INPUT_TYPE_PREFIX}${type.name}`, this.schema),
+          type: getInputType(type.name, this.schema),
         },
         {
           name: 'where',
-          type: getInputType(`${ModelDirective.UPDATE_INPUT_TYPE_PREFIX}${type.name}`, this.schema),
+          type: getInputType(type.name, this.schema),
         } as any,
         {
           name: 'upsert',

--- a/packages/graphql-crud/src/ModelDirective.ts
+++ b/packages/graphql-crud/src/ModelDirective.ts
@@ -1,5 +1,6 @@
 import {
   defaultFieldResolver,
+  getNamedType,
   getNullableType,
   GraphQLBoolean,
   GraphQLID,
@@ -7,13 +8,18 @@ import {
   GraphQLObjectType,
 } from 'graphql';
 import { SchemaDirectiveVisitor } from 'graphql-tools';
+import {
+  isPlainObject,
+  merge,
+} from 'lodash';
 import * as pluralize from 'pluralize';
 import {
   addInputTypesForObjectType,
   generateFieldNames,
   getInputType,
+  hasDirective,
   Store,
-  validateUpdateInputData,
+  validateInputData,
 } from './';
 
 export interface ResolverContext {
@@ -99,6 +105,217 @@ export class ModelDirective extends SchemaDirectiveVisitor {
     });
   }
 
+  private async visitNestedModels({ data, type, modelFunction }) {
+    const res = {};
+
+    for (const key of Object.keys(data)) {
+      const value = data[key];
+      const field = getNamedType(type.getFields()[key]) as any;
+
+      const fieldType = getNamedType(field.type);
+
+      if (isPlainObject(value) && hasDirective('model', fieldType)) {
+        const foundObject = await modelFunction(fieldType, value);
+        res[key] = foundObject;
+      }
+
+      if (Array.isArray(value) && value.every((v) => isPlainObject(v))) {
+        const createdObjects: any[] = [];
+
+        for (const v of value) {
+          const foundObject = await modelFunction(fieldType, v);
+          createdObjects.push(foundObject);
+        }
+
+        res[key] = createdObjects;
+      }
+    }
+
+    return res;
+  }
+
+  private pluckModelObjectIds(data) {
+    return Object
+      .keys(data)
+      .reduce((res, key) => {
+        if (key === 'id') {
+          return {
+            ...res,
+            [key]: data[key],
+          };
+        }
+        if (isPlainObject(data[key])) {
+          return {
+            ...res,
+            [key]: this.pluckModelObjectIds(data[key]),
+          };
+        }
+        if (Array.isArray(data[key])) {
+          return {
+            ...res,
+            [key]: data[key].map((value) => this.pluckModelObjectIds(value)),
+          };
+        }
+        return res;
+      }, {});
+  }
+
+  private findQueryResolver(type) {
+    return async (root, args: FindResolverArgs, context: ResolverContext) => {
+      const initialData: object[] = await context.directives.model.store.find({
+        where: args.where,
+        type,
+      });
+
+      if (!initialData) {
+        return null;
+      }
+
+      const results = await Promise.all(
+        initialData
+          .map(async (data) => {
+            const nestedData = await this.visitNestedModels({
+              type,
+              data,
+              modelFunction: async (type, value) => {
+                const found = await this.findOneQueryResolver(type)(root, { ...args, where: value }, context);
+                return found;
+              },
+            });
+            return merge({}, data, nestedData);
+          },
+        ),
+      );
+
+      return results;
+    };
+  }
+
+  private findOneQueryResolver(type) {
+    return async (root, args: FindOneResolverArgs, context: ResolverContext) => {
+      const rootObject = await context.directives.model.store.findOne({
+        where: args.where,
+        type,
+      });
+
+      if (!rootObject) {
+        return null;
+      }
+
+      const nestedObjects = await this.visitNestedModels({
+        type,
+        data: rootObject,
+        modelFunction: (type, value) => this.findOneQueryResolver(type)(root, { ...args, where: value }, context),
+      });
+
+      return merge({}, rootObject, nestedObjects);
+    };
+  }
+
+  private createMutationResolver(type) {
+    return async (root, args: CreateResolverArgs, context: ResolverContext) => {
+      validateInputData({
+        data: args.data,
+        type,
+        schema: this.schema,
+      });
+
+      const relatedObjects = await this.visitNestedModels({
+        type,
+        data: args.data,
+        modelFunction: async (type, value) => {
+          if (value.id) {
+            const found = await this.findOneQueryResolver(type)(root, { where: { id: value.id } }, context);
+            return found;
+          }
+          const createdObject = await this.createMutationResolver(type)(root, { ...args, data: value }, context);
+          return createdObject;
+        },
+      });
+
+      const objectIds = this.pluckModelObjectIds(relatedObjects);
+
+      const rootObject = await context.directives.model.store.create({
+        data: {
+          ...args.data,
+          ...objectIds,
+        },
+        type,
+      });
+
+      const mergedObjects = {
+        ...rootObject,
+        ...relatedObjects,
+      };
+
+      return mergedObjects;
+    };
+  }
+
+  private updateResolver(type) {
+    return async (root, args: UpdateResolverArgs, context: ResolverContext) => {
+      validateInputData({
+        data: args.data,
+        type,
+        schema: this.schema,
+      });
+
+      const relatedObjects = await this.visitNestedModels({
+        type,
+        data: args.data,
+        modelFunction: async (type, value) => {
+          if (value.id) {
+            const updated = await this.updateResolver(type)(root, {
+              data: value,
+              where: {
+                id: value.id,
+              },
+              upsert: false,
+            }, context);
+            if (updated) {
+              const foundObject = await this.findOneQueryResolver(type)(root, {
+                where: {
+                  id: value.id,
+                },
+              }, context);
+
+              return foundObject;
+            }
+          }
+          return value;
+        },
+      });
+
+      const objectIds = this.pluckModelObjectIds(relatedObjects);
+
+      const updated = await context.directives.model.store.update({
+        where: args.where,
+        data: {
+          ...args.data,
+          ...objectIds,
+        },
+        upsert: args.upsert,
+        type,
+      });
+
+      if (!updated) {
+        throw new Error(`Failed to update ${type}`);
+      }
+
+      const rootObject = await context.directives.model.store.findOne({
+        where: args.where,
+        type,
+      });
+
+      const mergedObjects = {
+        ...rootObject,
+        ...relatedObjects,
+      };
+
+      return mergedObjects;
+    };
+  }
+
   private addMutations(type: GraphQLObjectType) {
     const names = generateFieldNames(type.name);
 
@@ -116,12 +333,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
           type: (this.schema.getType(names.input.type)),
         },
       ],
-      resolve: (root, args: CreateResolverArgs, context: ResolverContext) => {
-        return context.directives.model.store.create({
-          data: args.data,
-          type,
-        });
-      },
+      resolve: this.createMutationResolver(type),
       isDeprecated: false,
     };
 
@@ -129,7 +341,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
 
     (this.schema.getMutationType() as any).getFields()[names.mutation.update] = {
       name: names.mutation.update,
-      type: GraphQLBoolean,
+      type,
       description: `Update a ${type.name}`,
       args: [
         {
@@ -145,20 +357,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
           type: GraphQLBoolean,
         } as any,
       ],
-      resolve: (root, args: UpdateResolverArgs, context: ResolverContext) => {
-        validateUpdateInputData({
-          data: args.data,
-          type,
-          schema: this.schema,
-        });
-
-        return context.directives.model.store.update({
-          where: args.where,
-          data: args.data,
-          upsert: args.upsert,
-          type,
-        });
-      },
+      resolve: this.updateResolver(type),
       isDeprecated: false,
     };
 
@@ -199,12 +398,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
           type: (this.schema.getType(names.input.type)),
         } as any,
       ],
-      resolve: (root, args: FindOneResolverArgs, context: ResolverContext) => {
-        return context.directives.model.store.findOne({
-          where: args.where,
-          type,
-        });
-      },
+      resolve: this.findOneQueryResolver(type),
       isDeprecated: false,
     };
 
@@ -220,12 +414,7 @@ export class ModelDirective extends SchemaDirectiveVisitor {
           type: (this.schema.getType(names.input.type)),
         } as any,
       ],
-      resolve: (root, args: FindResolverArgs, context: ResolverContext) => {
-        return context.directives.model.store.find({
-          where: args.where,
-          type,
-        });
-      },
+      resolve: this.findQueryResolver(type),
       isDeprecated: false,
     };
   }

--- a/packages/graphql-crud/src/addInputTypesForObjectType.ts
+++ b/packages/graphql-crud/src/addInputTypesForObjectType.ts
@@ -18,7 +18,8 @@ export interface AddInputTypesForObjectTypeProps {
   objectType: GraphQLObjectType;
   schema: GraphQLSchema;
   prefix?: string;
-  modifyField?: (field: any) => any;
+  modifyField?: (field: any, parent: any) => any;
+  parent?: any;
 }
 
 export const createInputField = (field, inputType) => {
@@ -43,7 +44,8 @@ export const addInputTypesForObjectType = ({
   objectType,
   schema,
   prefix = '',
-  modifyField = (field) => field,
+  modifyField = (field, parent) => field,
+  parent = null,
 }: AddInputTypesForObjectTypeProps) => {
   // Fields of an input type cannot have resolvers
   const fields = omitResolvers(objectType.getFields());
@@ -85,6 +87,7 @@ export const addInputTypesForObjectType = ({
             schema,
             prefix,
             modifyField,
+            parent: objectType,
           });
           field = createInputField(field, newInputType);
         }
@@ -92,7 +95,7 @@ export const addInputTypesForObjectType = ({
 
       return {
         ...res,
-        [key]: modifyField(field),
+        [key]: modifyField(field, parent),
       };
     }, {});
 

--- a/packages/graphql-crud/src/index.ts
+++ b/packages/graphql-crud/src/index.ts
@@ -7,7 +7,7 @@ export * from './generateFieldNames';
 export * from './omitResolvers';
 export * from './addInputTypesForObjectType';
 export * from './util';
-export * from './validateUpdateInputData';
+export * from './validateInputData';
 
 import { DefaultDirective } from './DefaultDirective';
 import { ModelDirective } from './ModelDirective';

--- a/packages/graphql-crud/src/util.ts
+++ b/packages/graphql-crud/src/util.ts
@@ -4,6 +4,9 @@ import {
   GraphQLObjectType,
   GraphQLSchema,
 } from 'graphql';
+import {
+  get,
+} from 'lodash';
 
 export const toInputObjectTypeName = (name: string): string => `${name}InputType`;
 
@@ -17,3 +20,16 @@ export const getInputType = (typeName: string, schema: GraphQLSchema): GraphQLIn
 };
 
 export const isNonNullable = (type) => type.astNode && type.astNode.type.kind === 'NonNullType';
+
+export const getObjectTypeFromInputType = (typeName: string, schema: GraphQLSchema): GraphQLObjectType => {
+  const type = schema.getType(typeName.replace('InputType', ''));
+  return type as GraphQLObjectType;
+};
+
+export const hasDirective = (directive, type) => {
+  const directives = get(type, ['astNode', 'directives']);
+  if (directives) {
+    return directives.find((d) => d.name.value === directive);
+  }
+  return false;
+};

--- a/packages/graphql-crud/src/validateInputData.ts
+++ b/packages/graphql-crud/src/validateInputData.ts
@@ -13,7 +13,7 @@ import {
   isNonNullable,
 } from './';
 
-export interface ValidateUpdateInputDataProps {
+export interface ValidateInputDataProps {
   type: GraphQLObjectType;
   schema: GraphQLSchema;
   data: object;
@@ -21,7 +21,7 @@ export interface ValidateUpdateInputDataProps {
 
 // For every null value in the input data
 // check that it can be nullable by check the type definition.
-export const validateUpdateInputData = (props: ValidateUpdateInputDataProps) => {
+export const validateInputData = (props: ValidateInputDataProps) => {
   if (isEmpty(props.data)) {
     throw new Error('data input object is missing');
   }
@@ -34,7 +34,7 @@ export const validateUpdateInputData = (props: ValidateUpdateInputDataProps) => 
       const field = fields[key];
       const value = props.data[key];
       if (isPlainObject(value)) {
-        validateUpdateInputData({
+        validateInputData({
           schema: props.schema,
           data: value,
           type: getNullableType(field.type) as any,

--- a/packages/graphql-crud/src/validateInputData.ts
+++ b/packages/graphql-crud/src/validateInputData.ts
@@ -29,10 +29,11 @@ export const validateInputData = (props: ValidateInputDataProps) => {
   const fields = props.type.getFields();
 
   Object
-    .keys(props.data)
+    .keys(fields)
     .forEach((key) => {
       const field = fields[key];
       const value = props.data[key];
+      // Encountered an input object within the data. Recursively call this function.
       if (isPlainObject(value)) {
         validateInputData({
           schema: props.schema,
@@ -40,7 +41,9 @@ export const validateInputData = (props: ValidateInputDataProps) => {
           type: getNullableType(field.type) as any,
         });
       } else {
-        if (value === null && isNonNullable(field)) {
+        // IF the field value provided is null and the field is non nullable
+        // OR the field was not provided but is marked as non nullable in the input type
+        if (value === null && isNonNullable(field) || !props.data[key] && isNonNullable(field)) {
           throw new Error(`${props.type.name}.${field.name} must not be null`);
         }
       }

--- a/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
+++ b/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
@@ -4,6 +4,7 @@ exports[`ModelDirective produces the expected schema 1`] = `
 "type Author {
   name: String
   books: [Book]
+  favoriteBook: Book
 
   \\"\\"\\"Unique ID\\"\\"\\"
   id: ID
@@ -12,6 +13,7 @@ exports[`ModelDirective produces the expected schema 1`] = `
 input AuthorInputType {
   name: String
   books: [BookInputType]
+  favoriteBook: BookInputType
 
   \\"\\"\\"Unique ID\\"\\"\\"
   id: ID
@@ -40,7 +42,7 @@ type Mutation {
   createAuthor(data: AuthorInputType): Author
 
   \\"\\"\\"Update a Author\\"\\"\\"
-  updateAuthor(data: UpdateAuthorInputType, where: UpdateAuthorInputType, upsert: Boolean): Boolean
+  updateAuthor(data: UpdateAuthorInputType, where: UpdateAuthorInputType, upsert: Boolean): Author
 
   \\"\\"\\"Remove a Author\\"\\"\\"
   removeAuthor(where: AuthorInputType): Boolean
@@ -49,7 +51,7 @@ type Mutation {
   createBook(data: BookInputType): Book
 
   \\"\\"\\"Update a Book\\"\\"\\"
-  updateBook(data: UpdateBookInputType, where: UpdateBookInputType, upsert: Boolean): Boolean
+  updateBook(data: UpdateBookInputType, where: UpdateBookInputType, upsert: Boolean): Book
 
   \\"\\"\\"Remove a Book\\"\\"\\"
   removeBook(where: BookInputType): Boolean
@@ -74,6 +76,7 @@ type Query {
 input UpdateAuthorInputType {
   name: String
   books: [UpdateBookInputType]
+  favoriteBook: UpdateBookInputType
 
   \\"\\"\\"Unique ID\\"\\"\\"
   id: ID

--- a/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
+++ b/packages/graphql-crud/test/__snapshots__/ModelDirective.test.ts.snap
@@ -42,7 +42,7 @@ type Mutation {
   createAuthor(data: AuthorInputType): Author
 
   \\"\\"\\"Update a Author\\"\\"\\"
-  updateAuthor(data: UpdateAuthorInputType, where: UpdateAuthorInputType, upsert: Boolean): Author
+  updateAuthor(data: AuthorInputType, where: AuthorInputType, upsert: Boolean): Author
 
   \\"\\"\\"Remove a Author\\"\\"\\"
   removeAuthor(where: AuthorInputType): Boolean
@@ -51,7 +51,7 @@ type Mutation {
   createBook(data: BookInputType): Book
 
   \\"\\"\\"Update a Book\\"\\"\\"
-  updateBook(data: UpdateBookInputType, where: UpdateBookInputType, upsert: Boolean): Book
+  updateBook(data: BookInputType, where: BookInputType, upsert: Boolean): Book
 
   \\"\\"\\"Remove a Book\\"\\"\\"
   removeBook(where: BookInputType): Boolean
@@ -71,23 +71,6 @@ type Query {
 
   \\"\\"\\"Find multiple Books\\"\\"\\"
   books(where: BookInputType): [Book]
-}
-
-input UpdateAuthorInputType {
-  name: String
-  books: [UpdateBookInputType]
-  favoriteBook: UpdateBookInputType
-
-  \\"\\"\\"Unique ID\\"\\"\\"
-  id: ID
-}
-
-input UpdateBookInputType {
-  name: String
-  authors: [UpdateAuthorInputType]
-
-  \\"\\"\\"Unique ID\\"\\"\\"
-  id: ID
 }
 "
 `;

--- a/packages/graphql-crud/test/typeDefs.ts
+++ b/packages/graphql-crud/test/typeDefs.ts
@@ -2,6 +2,7 @@ export default `
 type Author @model {
   name: String
   books: [Book]
+  favoriteBook: Book
 }
 
 type Book @model {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1567,6 +1567,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql-crud@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-crud/-/graphql-crud-0.0.2.tgz#e3be36889a70e157ddb77564a77351228c43b8fa"
+  dependencies:
+    camel-case "^3.0.0"
+    clone-deep "^3.0.1"
+    lodash "^4.17.5"
+    pascal-case "^2.0.1"
+    pluralize "^7.0.0"
+
 graphql-tools@2.23.1:
   version "2.23.1"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.23.1.tgz#23f43000e2b9dc5a89920fe846fc5f71a320efdb"


### PR DESCRIPTION
Detects fields which are a `GraphQLObjectType` (the type must have an `@model` directive) in queries and mutations and handles establishing relationships between models. 

For mutations this means extracting ids out of the newly created/updated related objects and writing that id to the root object. 

For queries this means using the ids in the root object to find related objects.

**TODO**

- [ ] Comments
- [ ] More tests

Closes #27 #16 